### PR TITLE
bugfix: Add graphql as a dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "@aws-cdk/aws-apigateway": "^1.71.0",
     "@aws-cdk/aws-lambda": "^1.71.0",
     "@aws-cdk/core": "1.71.0",
+    "graphql": "^15.5.3",
     "source-map-support": "^0.5.16"
   }
 }


### PR DESCRIPTION
Without that, apollo-server-lambda will not work and throw error.

May require update in the article https://tlakomy.com/build-a-simple-graphql-server-with-apollo-and-cdk as well.